### PR TITLE
Add configurable role limits

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -18,5 +18,10 @@
     "password": "",
     "database": "botranktir",
     "charset": "utf8mb4"
+  },
+  "limits": {
+    "307433337126125568": {
+      "rolesPerUser": 10
+    }
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,7 @@ const config = require('../config/config.json');
 // Set up the database connection
 global['knex'] = require('knex')({
     client: 'mysql',
-    connection: config.database,
+    connection: config.database
 });
 
 const client = new CommandoClient({
@@ -16,16 +16,13 @@ const client = new CommandoClient({
     owner: config.bot.owner,
     disableEveryone: true,
     commandEditableDuration: 0,
-    messageCacheMaxSize: config.bot.messageCache,
+    messageCacheMaxSize: config.bot.messageCache
 });
 client.registry
     .registerDefaultTypes()
     .registerDefaultGroups()
     .registerDefaultCommands(config.defaultCommands)
-    .registerGroups([
-        ['general', 'General'],
-        ['manage', 'Managing'],
-    ])
+    .registerGroups([['general', 'General'], ['manage', 'Managing']])
     .registerCommandsIn(path.join(__dirname, 'commands'));
 
 // Login the bot with the forwarded token. If it fails, output the error via the forwarded function
@@ -37,7 +34,7 @@ client.once('ready', async () => {
     await ready.handle();
 });
 
-const messageReactionAdd = new (require('./events/messageReactionAdd.js'))(client);
+const messageReactionAdd = new (require('./events/messageReactionAdd.js'))(client, config.limits);
 const messageReactionRemove = new (require('./events/messageReactionRemove.js'))(client);
 
 // We have to use the raw event in case the message is not cached

--- a/src/app.js
+++ b/src/app.js
@@ -49,3 +49,9 @@ client.on('raw', event => {
         messageReactionRemove.handle(data.guild_id, data.channel_id, data.message_id, emoji, data.user_id);
     }
 });
+
+// Graceful stop with pm2
+process.on('SIGINT', () => {
+    client.destroy();
+    process.exit(0);
+});

--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,7 @@ const config = require('../config/config.json');
 // Set up the database connection
 global['knex'] = require('knex')({
     client: 'mysql',
-    connection: config.database
+    connection: config.database,
 });
 
 const client = new CommandoClient({
@@ -16,7 +16,7 @@ const client = new CommandoClient({
     owner: config.bot.owner,
     disableEveryone: true,
     commandEditableDuration: 0,
-    messageCacheMaxSize: config.bot.messageCache
+    messageCacheMaxSize: config.bot.messageCache,
 });
 client.registry
     .registerDefaultTypes()

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -1,11 +1,15 @@
+const Discord = require('discord.js');
+
 module.exports = class MessageReactionAdd {
     /**
      * MessageReactionAdd class for handling the MESSAGE_REACTION_ADD event.
      *
      * @param   client
+     * @param   limits
      */
-    constructor(client) {
+    constructor(client, limits) {
         this.client = client;
+        this.limits = limits;
     }
 
     /**
@@ -29,6 +33,31 @@ module.exports = class MessageReactionAdd {
         const guildInstance = this.client.guilds.get(guild);
         const member = guildInstance.members.get(user);
 
+        if (!this.validate(guild, member)) {
+            const channelInstance = guildInstance.channels.get(channel);
+            const messageInstance = await new Discord.Message(this.client, { id: message }, channelInstance).fetch();
+            await messageInstance.reactions
+                .filter(v => v.emoji.id === emoji || v.emoji.name === emoji)
+                .array()[0]
+                .users.remove(member);
+
+            return member;
+        }
         return await member.roles.add(role).catch(console.error);
+    }
+
+    /**
+     * Ensure the user has not reached limits
+     *
+     * @param {number|string} guild
+     * @param {GuildMember} member
+     */
+    validate(guild, member) {
+        return (
+            member.roles
+                .array()
+                .map(role => role.id)
+                .filter(roleManager.isManagedRole.bind(roleManager)).length < this.limits[guild].rolesPerUser
+        );
     }
 };

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -34,6 +34,7 @@ module.exports = class MessageReactionAdd {
         const member = guildInstance.members.get(user);
 
         if (!this.validate(guild, member)) {
+            // Remove the users failed reaction
             const channelInstance = guildInstance.channels.get(channel);
             const messageInstance = await new Discord.Message(this.client, { id: message }, channelInstance).fetch();
             await messageInstance.reactions

--- a/src/lib/RoleManager.js
+++ b/src/lib/RoleManager.js
@@ -170,7 +170,6 @@ module.exports = class ManageRoles {
      * @param {number|string} role
      */
     isManagedRole(role) {
-        console.log(role, this.managedRoles);
         return role in this.managedRoles;
     }
 };


### PR DESCRIPTION
Limits the number of roles a user can automatically add via reactions to avoid role spam. A reaction failing this validation will be removed, so the user can remove one and try again. Only roles managed by the bot are considered.