### PR TITLE
v2.2.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # To obtain a token, visit the following page: https://discord.com/developers/applications
 BOT_TOKEN=
+# Command prefix used in the development mode (overrides the guild prefix)
 BOT_PREFIX=+
 BOT_OWNER=144872893279371264,66281547510054912
 BOT_MESSAGE_CACHE=100

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ The bot is using [PM2](http://pm2.keymetrics.io/) and thus, it can be run under 
 - **Production:** `npm run prod`
 - **Development:** `npm run dev`
 
+## Inviting the Bot
+
+As the bot has been built with keeping in mind it can be used in more than one Discord guild, other users
+can invite the bot to their server through the `[p]join` command. To make this possible, make sure you have
+enabled the **Public Bot** option in the Discord application settings. On top of that, the value of the
+`invite` configuration must equal to `true` (it is the default value as well).
+
+If you want to use this bot just for yourself, disable the above-mentioned option in the Discord application
+settings, and change the value of the `invite` configuration to `false`.
+
 ## Discord Intents
 
 Botranktir needs both **Presence** and **Server Members Intents** to work flawlessly, as it is described in

--- a/config/config.json
+++ b/config/config.json
@@ -6,6 +6,12 @@
         "guild": true,
         "hidden": true
     },
+    "invite": {
+        "name": "Bot invites",
+        "description": "Whether the bot can be invited to other guilds by users. Possible values: `true`, `false`",
+        "defaultValue": "true",
+        "guild": false
+    },
     "limit": {
         "name": "Maximum reaction roles",
         "description": "Specify the maximum amount of reaction roles per a user. 0 = disabled",

--- a/config/config.json
+++ b/config/config.json
@@ -8,7 +8,7 @@
     },
     "invite": {
         "name": "Bot invites",
-        "description": "Whether the bot can be invited to other guilds by users. Possible values: `true`, `false`",
+        "description": "Whether the bot can be invited to other guilds. Possible values: `true`, `false`",
         "defaultValue": "true",
         "guild": false
     },

--- a/config/config.json
+++ b/config/config.json
@@ -1,4 +1,11 @@
 {
+    "prefix": {
+        "name": "Command prefix",
+        "description": "Prefix used for calling commands in a guild.",
+        "defaultValue": "+",
+        "guild": true,
+        "hidden": true
+    },
     "limit": {
         "name": "Maximum reaction roles",
         "description": "Specify the maximum amount of reaction roles per a user. 0 = disabled",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,31 @@
 {
     "name": "botranktir",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-            "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+            "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.10.1"
+                "@babel/highlight": "^7.10.4"
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-            "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+            "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
             "dev": true
         },
         "@babel/highlight": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-            "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.10.1",
+                "@babel/helper-validator-identifier": "^7.10.4",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -438,9 +438,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.0.13",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-            "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
+            "version": "14.0.14",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
+            "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ=="
         },
         "@types/numeral": {
             "version": "0.0.28",
@@ -458,37 +458,46 @@
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.2.0.tgz",
-            "integrity": "sha512-UbJBsk+xO9dIFKtj16+m42EvUvsjZbbgQ2O5xSTSfVT1Z3yGkL90DVu0Hd3029FZ5/uBgl+F3Vo8FAcEcqc6aQ==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.5.0.tgz",
+            "integrity": "sha512-zGNOrVi5Wz0jcjUnFZ6QUD0MCox5hBuVwemGCew2qJzUX5xPoyR+0EzS5qD5qQXL/vnQ8Eu+nv03tpeFRwLrDg==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/typescript-estree": "3.2.0",
+                "@typescript-eslint/types": "3.5.0",
+                "@typescript-eslint/typescript-estree": "3.5.0",
                 "eslint-scope": "^5.0.0",
                 "eslint-utils": "^2.0.0"
             }
         },
         "@typescript-eslint/parser": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.2.0.tgz",
-            "integrity": "sha512-Vhu+wwdevDLVDjK1lIcoD6ZbuOa93fzqszkaO3iCnmrScmKwyW/AGkzc2UvfE5TCoCXqq7Jyt6SOXjsIlpqF4A==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.5.0.tgz",
+            "integrity": "sha512-sU07VbYB70WZHtgOjH/qfAp1+OwaWgrvD1Km1VXqRpcVxt971PMTU7gJtlrCje0M+Sdz7xKAbtiyIu+Y6QdnVA==",
             "dev": true,
             "requires": {
                 "@types/eslint-visitor-keys": "^1.0.0",
-                "@typescript-eslint/experimental-utils": "3.2.0",
-                "@typescript-eslint/typescript-estree": "3.2.0",
+                "@typescript-eslint/experimental-utils": "3.5.0",
+                "@typescript-eslint/types": "3.5.0",
+                "@typescript-eslint/typescript-estree": "3.5.0",
                 "eslint-visitor-keys": "^1.1.0"
             }
         },
+        "@typescript-eslint/types": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.5.0.tgz",
+            "integrity": "sha512-Dreqb5idi66VVs1QkbAwVeDmdJG+sDtofJtKwKCZXIaBsINuCN7Jv5eDIHrS0hFMMiOvPH9UuOs4splW0iZe4Q==",
+            "dev": true
+        },
         "@typescript-eslint/typescript-estree": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.2.0.tgz",
-            "integrity": "sha512-uh+Y2QO7dxNrdLw7mVnjUqkwO/InxEqwN0wF+Za6eo3coxls9aH9kQ/5rSvW2GcNanebRTmsT5w1/92lAOb1bA==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.5.0.tgz",
+            "integrity": "sha512-Na71ezI6QP5WVR4EHxwcBJgYiD+Sre9BZO5iJK2QhrmRPo/42+b0no/HZIrdD1sjghzlYv7t+7Jis05M1uMxQg==",
             "dev": true,
             "requires": {
+                "@typescript-eslint/types": "3.5.0",
+                "@typescript-eslint/visitor-keys": "3.5.0",
                 "debug": "^4.1.1",
-                "eslint-visitor-keys": "^1.1.0",
                 "glob": "^7.1.6",
                 "is-glob": "^4.0.1",
                 "lodash": "^4.17.15",
@@ -512,6 +521,15 @@
                 }
             }
         },
+        "@typescript-eslint/visitor-keys": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.5.0.tgz",
+            "integrity": "sha512-7cTp9rcX2sz9Z+zua9MCOX4cqp5rYyFD5o8LlbSpXrMTXoRdngTtotRZEkm8+FNMHPWYFhitFK+qt/brK8BVJQ==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.1.0"
+            }
+        },
         "abort-controller": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -521,9 +539,9 @@
             }
         },
         "acorn": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-            "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+            "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
             "dev": true
         },
         "acorn-jsx": {
@@ -568,23 +586,6 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
             "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
-        },
-        "ansi-escapes": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-            "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-            "dev": true,
-            "requires": {
-                "type-fest": "^0.11.0"
-            },
-            "dependencies": {
-                "type-fest": {
-                    "version": "0.11.0",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-                    "dev": true
-                }
-            }
         },
         "ansi-regex": {
             "version": "3.0.0",
@@ -882,12 +883,6 @@
                 "supports-color": "^7.1.0"
             }
         },
-        "chardet": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-            "dev": true
-        },
         "charm": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
@@ -960,15 +955,6 @@
                 }
             }
         },
-        "cli-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-            "dev": true,
-            "requires": {
-                "restore-cursor": "^3.1.0"
-            }
-        },
         "cli-tableau": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/cli-tableau/-/cli-tableau-2.0.0.tgz",
@@ -977,12 +963,6 @@
                 "chalk": "3.0.0",
                 "mocha": "^7.1.1"
             }
-        },
-        "cli-width": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-            "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
-            "dev": true
         },
         "cliui": {
             "version": "5.0.0",
@@ -1302,9 +1282,9 @@
             }
         },
         "emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
             "dev": true
         },
         "end-of-stream": {
@@ -1400,9 +1380,9 @@
             }
         },
         "eslint": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.2.0.tgz",
-            "integrity": "sha512-B3BtEyaDKC5MlfDa2Ha8/D6DsS4fju95zs0hjS3HdGazw+LNayai38A25qMppK37wWGWNYSPOR6oYzlz5MHsRQ==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.4.0.tgz",
+            "integrity": "sha512-gU+lxhlPHu45H3JkEGgYhWhkR9wLHHEXC9FbWFnTlEkbKyZKWgWRLgf61E8zWmBuI6g5xKBph9ltg3NtZMVF8g==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -1411,6 +1391,7 @@
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.0.1",
                 "doctrine": "^3.0.0",
+                "enquirer": "^2.3.5",
                 "eslint-scope": "^5.1.0",
                 "eslint-utils": "^2.0.0",
                 "eslint-visitor-keys": "^1.2.0",
@@ -1424,7 +1405,6 @@
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
-                "inquirer": "^7.0.0",
                 "is-glob": "^4.0.0",
                 "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -1520,18 +1500,18 @@
             }
         },
         "eslint-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-            "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+            "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
             "dev": true,
             "requires": {
                 "eslint-visitor-keys": "^1.1.0"
             }
         },
         "eslint-visitor-keys": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",
-            "integrity": "sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+            "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
             "dev": true
         },
         "esm": {
@@ -1729,17 +1709,6 @@
                 }
             }
         },
-        "external-editor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-            "dev": true,
-            "requires": {
-                "chardet": "^0.7.0",
-                "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
-            }
-        },
         "extglob": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -1818,15 +1787,6 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
             "integrity": "sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA="
-        },
-        "figures": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-            "dev": true,
-            "requires": {
-                "escape-string-regexp": "^1.0.5"
-            }
         },
         "file-entry-cache": {
             "version": "5.0.1",
@@ -2301,44 +2261,6 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
-        "inquirer": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-            "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
-            "dev": true,
-            "requires": {
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^3.0.0",
-                "cli-cursor": "^3.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^3.0.3",
-                "figures": "^3.0.0",
-                "lodash": "^4.17.15",
-                "mute-stream": "0.0.8",
-                "run-async": "^2.4.0",
-                "rxjs": "^6.5.3",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0",
-                "through": "^2.3.6"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.0"
-                    }
-                }
-            }
-        },
         "interpret": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.0.0.tgz",
@@ -2445,9 +2367,9 @@
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
             "dev": true
         },
         "is-glob": {
@@ -2775,12 +2697,6 @@
             "requires": {
                 "mime-db": "1.44.0"
             }
-        },
-        "mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
@@ -3209,15 +3125,6 @@
                 "wrappy": "1"
             }
         },
-        "onetime": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-            "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-            "dev": true,
-            "requires": {
-                "mimic-fn": "^2.1.0"
-            }
-        },
         "optionator": {
             "version": "0.8.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -3239,12 +3146,6 @@
                 "macos-release": "^2.2.0",
                 "windows-release": "^3.1.0"
             }
-        },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-            "dev": true
         },
         "p-finally": {
             "version": "1.0.0",
@@ -3681,16 +3582,6 @@
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
-        "restore-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-            "dev": true,
-            "requires": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
-            }
-        },
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -3705,25 +3596,10 @@
                 "glob": "^7.1.3"
             }
         },
-        "run-async": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-            "dev": true
-        },
         "run-series": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.8.tgz",
             "integrity": "sha512-+GztYEPRpIsQoCSraWHDBs9WVy4eVME16zhOtDB4H9J4xN0XRhknnmLOl+4gRgZtu8dpp9N/utSPjKH/xmDzXg=="
-        },
-        "rxjs": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-            "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.9.0"
-            }
         },
         "safe-buffer": {
             "version": "5.1.2",
@@ -3847,12 +3723,6 @@
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
                     "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 }
             }
@@ -4081,29 +3951,29 @@
             "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
         },
         "string-width": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-            "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+            "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
             "dev": true,
             "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.0"
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
                 "strip-ansi": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^5.0.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }
@@ -4197,46 +4067,6 @@
                 "lodash": "^4.17.14",
                 "slice-ansi": "^2.1.0",
                 "string-width": "^3.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
-                "emoji-regex": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
-                }
             }
         },
         "tarn": {
@@ -4250,12 +4080,6 @@
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
         },
-        "through": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
-        },
         "thunkify": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
@@ -4265,15 +4089,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
             "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw=="
-        },
-        "tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "requires": {
-                "os-tmpdir": "~1.0.2"
-            }
         },
         "to-object-path": {
             "version": "0.3.0",
@@ -4394,9 +4209,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
-            "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+            "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
             "dev": true
         },
         "unc-path-regex": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "botranktir",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "Discord bot that manages roles after reacting to a message",
     "main": "build/src/app.js",
     "scripts": {
@@ -31,12 +31,12 @@
     },
     "devDependencies": {
         "@types/dotenv": "^8.2.0",
-        "@types/node": "^14.0.13",
+        "@types/node": "^14.0.14",
         "@types/numeral": "0.0.28",
         "@types/semver": "^7.3.1",
-        "@typescript-eslint/parser": "^3.2.0",
-        "eslint": "^7.2.0",
+        "@typescript-eslint/parser": "^3.5.0",
+        "eslint": "^7.4.0",
         "ts-node": "^8.10.2",
-        "typescript": "^3.9.5"
+        "typescript": "^3.9.6"
     }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import { ReadyEvent } from './events/ready.event';
 import { Channel, Collection, GuildEmoji, Intents, Message, MessageReaction, Role, Snowflake, User } from 'discord.js';
 import { CommandoClient, CommandoGuild } from 'discord.js-commando';
 import { ClientManager } from './managers/client.manager';
+import { ConfigurationManager } from './managers/configuration.manager';
 
 // Load config variables
 const config = dotenv.config({ path: '.env' });
@@ -61,7 +62,7 @@ intents.add(
 );
 
 const client = new CommandoClient({
-    commandPrefix: process.env.BOT_PREFIX,
+    commandPrefix: global.LOCAL ? process.env.BOT_PREFIX : ConfigurationManager.getDefaultValue('prefix'),
     owner: process.env.BOT_OWNER.split(','),
     commandEditableDuration: 0,
     messageCacheMaxSize: parseInt(process.env.BOT_MESSAGE_CACHE),

--- a/src/app.ts
+++ b/src/app.ts
@@ -29,6 +29,8 @@ if (config.error) {
 global['BOT_COLOR'] = 0xc4fcff;
 global['SUCCESS_COLOR'] = 0x6dcf84;
 
+global['LOCAL'] = process.env.LOCAL === 'true';
+
 // Set up the database connection
 const knex = Knex({
     client: 'mysql',

--- a/src/commands/general/help.command.ts
+++ b/src/commands/general/help.command.ts
@@ -24,7 +24,7 @@ module.exports = class HelpCommand extends Command {
         message: CommandoMessage,
         args: { command: string },
     ): Promise<Message | Message[]> {
-        const prefix = this.client.commandPrefix;
+        const prefix = message.guild.commandPrefix;
         const commands = this.client.registry.commands.clone().sort(this.sortCommands);
         // As message.message is not working, we need to cast the object instead to get that value
         const msg = <Message><unknown>message;

--- a/src/commands/general/join.command.ts
+++ b/src/commands/general/join.command.ts
@@ -19,7 +19,7 @@ module.exports = class JoinCommand extends Command {
     }
 
     hasPermission(message: CommandoMessage, ownerOverride?: boolean): boolean | string {
-        const canBeInvited = ConfigurationManager.get().getConfiguration('invite', message.guild.id) === 'true';
+        const canBeInvited = ConfigurationManager.get().getConfiguration('invite') === 'true';
         if (!this.client.isOwner(message.author) && (global.LOCAL || !canBeInvited)) {
             return 'this bot cannot be invited!';
         }

--- a/src/commands/general/join.command.ts
+++ b/src/commands/general/join.command.ts
@@ -1,0 +1,34 @@
+import { Command, CommandoClient, CommandoMessage } from 'discord.js-commando';
+import { Message } from 'discord.js';
+import { ConfigurationManager } from '../../managers/configuration.manager';
+
+module.exports = class JoinCommand extends Command {
+    constructor(client: CommandoClient) {
+        super(client, {
+            name: 'join',
+            group: 'general',
+            memberName: 'join',
+            description: 'Get the invite link for the bot.',
+            aliases: ['invite'],
+            examples: ['join'],
+            throttling: {
+                usages: 1,
+                duration: 30,
+            },
+        });
+    }
+
+    hasPermission(message: CommandoMessage, ownerOverride?: boolean): boolean | string {
+        const canBeInvited = ConfigurationManager.get().getConfiguration('invite', message.guild.id) === 'true';
+        if (!this.client.isOwner(message.author) && (global.LOCAL || !canBeInvited)) {
+            return 'this bot cannot be invited!';
+        }
+
+        return super.hasPermission(message, ownerOverride);
+    }
+
+    async run(message: CommandoMessage): Promise<Message | Message[]> {
+        const invite = await this.client.generateInvite('ADMINISTRATOR');
+        return message.say(`Invite ${this.client.user.username} to your guild: ${invite}`);
+    }
+};

--- a/src/commands/manage/config.command.ts
+++ b/src/commands/manage/config.command.ts
@@ -1,6 +1,6 @@
-import { Command, CommandoClient, CommandoMessage } from 'discord.js-commando';
 import * as Discord from 'discord.js';
 import * as DefaultConfig from '../../../config/config.json';
+import { Command, CommandoClient, CommandoMessage } from 'discord.js-commando';
 import { ConfigurationManager } from '../../managers/configuration.manager';
 import Configuration from '../../models/Configuration';
 
@@ -10,7 +10,7 @@ module.exports = class ConfigCommand extends Command {
             name: 'config',
             group: 'manage',
             memberName: 'config',
-            description: `Configure the bot. Use ${client.commandPrefix}config for more information.`,
+            description: 'Configure the bot. Use the `config` command for more information.',
             examples: [
                 'config',
                 'config options',
@@ -54,7 +54,7 @@ module.exports = class ConfigCommand extends Command {
         args: { action: string, key: string, value: string },
     ): Promise<Discord.Message | Discord.Message[]> {
         if (!args.action) {
-            return message.say(this.createHelp());
+            return message.say(this.createHelp(message.guild.commandPrefix));
         }
 
         if (args.action === 'options') {
@@ -73,7 +73,7 @@ module.exports = class ConfigCommand extends Command {
             return this.removeConfiguration(message, args.key);
         }
 
-        return message.replyEmbed(this.createHelp(), 'the action is invalid!');
+        return message.replyEmbed(this.createHelp(message.guild.commandPrefix), 'the action is invalid!');
     }
 
     /**
@@ -113,7 +113,7 @@ module.exports = class ConfigCommand extends Command {
     ): Promise<Discord.Message | Discord.Message[]> {
         // Check whether all parameters are provided (so they do not match the default value)
         if (key === '') {
-            return message.replyEmbed(this.createHelp(), 'no key has been provided!');
+            return message.replyEmbed(this.createHelp(message.guild.commandPrefix), 'no key has been provided!');
         }
         // Check the existence of the configuration
         if (!ConfigurationManager.doesConfigurationExist(key) || ConfigurationManager.isHidden(key)) {
@@ -178,10 +178,10 @@ module.exports = class ConfigCommand extends Command {
     ): Promise<Discord.Message | Discord.Message[]> {
         // Check whether all parameters are provided (so they do not match the default value)
         if (key === '') {
-            return message.replyEmbed(this.createHelp(), 'no key has been provided!');
+            return message.replyEmbed(this.createHelp(message.guild.commandPrefix), 'no key has been provided!');
         }
         if (value === '') {
-            return message.replyEmbed(this.createHelp(), 'no value has been provided!');
+            return message.replyEmbed(this.createHelp(message.guild.commandPrefix), 'no value has been provided!');
         }
         // Check the existence of the configuration
         if (!ConfigurationManager.doesConfigurationExist(key) || ConfigurationManager.isHidden(key)) {
@@ -216,7 +216,7 @@ module.exports = class ConfigCommand extends Command {
     ): Promise<Discord.Message | Discord.Message[]> {
         // Check whether all parameters are provided (so they do not match the default value)
         if (key === '') {
-            return message.replyEmbed(this.createHelp(), 'no key has been provided!');
+            return message.replyEmbed(this.createHelp(message.guild.commandPrefix), 'no key has been provided!');
         }
         // Check the existence of the configuration
         if (!ConfigurationManager.doesConfigurationExist(key) || ConfigurationManager.isHidden(key)) {
@@ -248,17 +248,17 @@ module.exports = class ConfigCommand extends Command {
     /**
      * Create an embed containing help for the command.
      */
-    protected createHelp(): Discord.MessageEmbed {
+    protected createHelp(prefix: string): Discord.MessageEmbed {
         return new Discord.MessageEmbed()
             .setTitle('Configuration')
             .setColor(global.BOT_COLOR)
             .setDescription(
                 'Modify changeable configuration variables for this bot.\n\n' +
-                `Type \`${this.client.commandPrefix}config options\` to view a list of valid configuration variables.\n\n` +
-                `To get all set configuration variables:\n\`${this.client.commandPrefix}config get\`\n\n` +
-                `To get a configuration variable:\n\`${this.client.commandPrefix}config get key\`\n\n` +
-                `To set a configuration variable:\n\`${this.client.commandPrefix}config set key value\`\n\n` +
-                `To remove a configuration variable:\n\`${this.client.commandPrefix}config remove key\``,
+                `Type \`${prefix}config options\` to view a list of valid configuration variables.\n\n` +
+                `To get all set configuration variables:\n\`${prefix}config get\`\n\n` +
+                `To get a configuration variable:\n\`${prefix}config get key\`\n\n` +
+                `To set a configuration variable:\n\`${prefix}config set key value\`\n\n` +
+                `To remove a configuration variable:\n\`${prefix}config remove key\``,
             );
     }
 };

--- a/src/commands/manage/config.command.ts
+++ b/src/commands/manage/config.command.ts
@@ -88,6 +88,9 @@ module.exports = class ConfigCommand extends Command {
 
         for (const key in DefaultConfig) {
             const config = ConfigurationManager.getDefaultConfiguration(key);
+            if (config.hidden) {
+                continue;
+            }
 
             embed.addField(
                 `${config.name} (${key})` + (!config.guild ? ' (**BOT**)' : ''),
@@ -113,7 +116,7 @@ module.exports = class ConfigCommand extends Command {
             return message.replyEmbed(this.createHelp(), 'no key has been provided!');
         }
         // Check the existence of the configuration
-        if (!ConfigurationManager.doesConfigurationExist(key)) {
+        if (!ConfigurationManager.doesConfigurationExist(key) || ConfigurationManager.isHidden(key)) {
             return message.reply('the configuration of this key could not be found!');
         }
 
@@ -142,11 +145,15 @@ module.exports = class ConfigCommand extends Command {
 
         // First, loop through global bot configurations
         ConfigurationManager.get().getGuild().forEach((value: string, key: string) => {
-            embed.addField(`${key} (**BOT**)`, `\`${value}\``);
+            if (!ConfigurationManager.isHidden(key)) {
+                embed.addField(`${key} (**BOT**)`, `\`${value}\``);
+            }
         });
         // Then, go through the guild configurations
         ConfigurationManager.get().getGuild(message.guild.id).forEach((value: string, key: string) => {
-            embed.addField(key, `\`${value}\``);
+            if (!ConfigurationManager.isHidden(key)) {
+                embed.addField(key, `\`${value}\``);
+            }
         });
 
         // As unmodified configuration values are not stored, let the user know that nothing has been changed
@@ -177,7 +184,7 @@ module.exports = class ConfigCommand extends Command {
             return message.replyEmbed(this.createHelp(), 'no value has been provided!');
         }
         // Check the existence of the configuration
-        if (!ConfigurationManager.doesConfigurationExist(key)) {
+        if (!ConfigurationManager.doesConfigurationExist(key) || ConfigurationManager.isHidden(key)) {
             return message.reply('the configuration of this key could not be found!');
         }
         // Check whether the user can modify this configuration
@@ -212,7 +219,7 @@ module.exports = class ConfigCommand extends Command {
             return message.replyEmbed(this.createHelp(), 'no key has been provided!');
         }
         // Check the existence of the configuration
-        if (!ConfigurationManager.doesConfigurationExist(key)) {
+        if (!ConfigurationManager.doesConfigurationExist(key) || ConfigurationManager.isHidden(key)) {
             return message.reply('the configuration of this key could not be found!');
         }
         // Check whether the user can remove the specific configuration

--- a/src/commands/manage/prefix.command.ts
+++ b/src/commands/manage/prefix.command.ts
@@ -1,0 +1,94 @@
+import { Command, CommandoClient, CommandoMessage } from 'discord.js-commando';
+import { Message } from 'discord.js';
+import { ConfigurationManager } from '../../managers/configuration.manager';
+import Configuration from '../../models/Configuration';
+
+module.exports = class PrefixCommand extends Command {
+    constructor(client: CommandoClient) {
+        super(client, {
+            name: 'prefix',
+            group: 'manage',
+            memberName: 'prefix',
+            description: 'Shows or sets the command prefix of the guild.',
+            details:
+                'If no prefix is provided, the current prefix will be shown. ' +
+                'If the prefix is "default", the prefix will be reset to the bot\'s default prefix. ' +
+                'Only administrators may change the prefix.\n' +
+                'The prefix can be only 2 characters long.',
+            format: '[prefix/"default"]',
+            examples: ['prefix', 'prefix +', 'prefix default'],
+            userPermissions: ['ADMINISTRATOR'],
+            guildOnly: true,
+            throttling: {
+                usages: 5,
+                duration: 15,
+            },
+            args: [
+                {
+                    key: 'prefix',
+                    prompt: 'What would you like to set the bot\'s prefix to?',
+                    type: 'string',
+                    default: '',
+                    validate: (value: string) => this.validatePrefix(value),
+                },
+            ],
+        });
+    }
+
+    async run(
+        message: CommandoMessage,
+        args: { prefix: string },
+    ): Promise<Message | Message[]> {
+        // Just output the prefix
+        if (!args.prefix) {
+            return message.say(
+                `The command prefix of the guild is \`${message.guild.commandPrefix}\`. ` +
+                `To run commands, use ${message.anyUsage('command')}`,
+            );
+        }
+
+        // In the development mode, the environment value for the prefix is forced
+        if (global.LOCAL) {
+            return message.reply('this bot does not support changing the command prefix!');
+        }
+
+        const defaultPrefix = ConfigurationManager.getDefaultValue('prefix');
+        const prefix = args.prefix.toLowerCase();
+
+        if (prefix === 'default') {
+            message.guild.commandPrefix = defaultPrefix;
+
+            await Configuration.deleteConfiguration('prefix', message.guild.id);
+            ConfigurationManager.get().removeConfiguration('prefix', message.guild.id);
+
+            return message.say(
+                `Reset the command prefix of the guild to the default (currently \`${defaultPrefix}\`). ` +
+                `To run commands, use ${message.anyUsage('command')}.`,
+            );
+        }
+
+        message.guild.commandPrefix = prefix;
+
+        await Configuration.setConfiguration('prefix', prefix, message.guild.id);
+        ConfigurationManager.get().updateConfiguration('prefix', prefix, message.guild.id);
+
+        return message.say(
+            `Set the command prefix of the guild to \`${prefix}\`. ` +
+            `To run commands, use ${message.anyUsage('command')}.`,
+        );
+    }
+
+    /**
+     * Validate the argument of the prefix.
+     *
+     * @param prefix
+     */
+    protected validatePrefix(prefix: string): boolean {
+        // Do not validate the prefix in the development mode as it cannot be changed
+        if (global.LOCAL) {
+            return true;
+        }
+
+        return !prefix.includes(' ') && (prefix.length <= 3 || prefix === 'default');
+    }
+};

--- a/src/commands/roles/add.command.ts
+++ b/src/commands/roles/add.command.ts
@@ -74,7 +74,7 @@ module.exports = class AddRoleCommand extends Command {
         ) {
             return message.reply(
                 'please, provide valid parameters! For more information, ' +
-                `run command \`${this.client.commandPrefix}help ${this.name}\``,
+                `run command \`${message.guild.commandPrefix}help ${this.name}\``,
             );
         }
 
@@ -104,7 +104,7 @@ module.exports = class AddRoleCommand extends Command {
 
         const moreDetailsText =
             'For more details, run this command: ' +
-            `\`${this.client.commandPrefix}fetchmessage #${args.channel.name} ${args.messageID}\``;
+            `\`${message.guild.commandPrefix}fetchmessage #${args.channel.name} ${args.messageID}\``;
         // The same emoji cannot be twice on the same message
         if (RoleManager.get().getRole(guild.id, args.channel.id, args.messageID, emoji.id)) {
             return message.reply(`this emoji has already been connected to a role on the message.\n${moreDetailsText}`);

--- a/src/commands/roles/del-all.command.ts
+++ b/src/commands/roles/del-all.command.ts
@@ -56,7 +56,7 @@ module.exports = class DeleteRoleCommand extends Command {
         ) {
             return message.reply(
                 'please, provide valid parameters! For more information, ' +
-                `run command \`${this.client.commandPrefix}help ${this.name}\``,
+                `run command \`${message.guild.commandPrefix}help ${this.name}\``,
             );
         }
 

--- a/src/commands/roles/del.command.ts
+++ b/src/commands/roles/del.command.ts
@@ -62,7 +62,7 @@ module.exports = class DeleteRoleCommand extends Command {
         ) {
             return message.reply(
                 'please, provide valid parameters! For more information, ' +
-                `run command \`${this.client.commandPrefix}help ${this.name}\``,
+                `run command \`${message.guild.commandPrefix}help ${this.name}\``,
             );
         }
 

--- a/src/commands/roles/fetch-message.command.ts
+++ b/src/commands/roles/fetch-message.command.ts
@@ -42,7 +42,7 @@ module.exports = class FetchMessageCommand extends Command {
         ) {
             return message.reply(
                 'please, provide valid parameters! For more information, ' +
-                `run command \`${this.client.commandPrefix}help ${this.name}\``,
+                `run command \`${message.guild.commandPrefix}help ${this.name}\``,
             );
         }
 

--- a/src/commands/roles/toggle.command.ts
+++ b/src/commands/roles/toggle.command.ts
@@ -61,7 +61,7 @@ module.exports = class ToggleRoleCommand extends Command {
         ) {
             return message.reply(
                 'please, provide valid parameters! For more information, ' +
-                `run command \`${this.client.commandPrefix}help ${this.name}\``,
+                `run command \`${message.guild.commandPrefix}help ${this.name}\``,
             );
 
         }

--- a/src/events/guild.create.event.ts
+++ b/src/events/guild.create.event.ts
@@ -24,6 +24,12 @@ export class GuildCreateEvent extends Event {
     async handle(): Promise<void> {
         console.log('joined guild', this.guild.id, this.guild.name);
 
+        // Change the command prefix for the guild only if the bot is not in
+        // the development mode as in such a case, the environment value is forced
+        if (!global.LOCAL) {
+            this.guild.commandPrefix = ConfigurationManager.get().getConfiguration('prefix', this.guild.id);
+        }
+
         // If data is cleared on leaving the guild, there is nothing left in
         // the database; nothing needs to be fetched
         if (process.env.CLEAR_GUILD === 'true') {

--- a/src/managers/client.manager.ts
+++ b/src/managers/client.manager.ts
@@ -1,6 +1,6 @@
 import Role from '../models/Role';
 import Configuration from '../models/Configuration';
-import { Client } from 'discord.js-commando';
+import { Client, CommandoGuild } from 'discord.js-commando';
 import { RoleManager } from './role.manager';
 import { ConfigurationManager } from './configuration.manager';
 import { TextChannel } from 'discord.js';
@@ -99,12 +99,31 @@ export class ClientManager {
             throw new Error('The instance is not initialized!');
         }
 
+        // Update the command prefix for all guilds
+        this.updateCommandPrefix();
+
         // Set interval for setting the activity as sometimes the activity is gone
         setInterval(ClientManager.setActivity, 60 * 1000, this.client);
         await ClientManager.setActivity(this.client);
 
         await this.clearConfigurations();
         await this.clearReactionRoles();
+    }
+
+    /**
+     * Load the command prefix for all guilds from the configuration.
+     *
+     * In the development mode, the command prefix is kept to default.
+     */
+    protected updateCommandPrefix(): void {
+        if (global.LOCAL) {
+            return;
+        }
+
+        for (const [guildId, guild] of this.client.guilds.cache) {
+            const commandoGuild = <CommandoGuild>guild;
+            commandoGuild.commandPrefix = ConfigurationManager.get().getConfiguration('prefix', guildId);
+        }
     }
 
     /**

--- a/src/managers/configuration.manager.ts
+++ b/src/managers/configuration.manager.ts
@@ -207,6 +207,20 @@ export class ConfigurationManager {
     }
 
     /**
+     * Determine whether the configuration should be hidden from the output.
+     *
+     * @param key
+     */
+    static isHidden(key: string): boolean {
+        if (!this.doesConfigurationExist(key)) {
+            return false;
+        }
+
+        const config = this.getDefaultConfiguration(key);
+        return config.hidden;
+    }
+
+    /**
      * Resolve the guild for the local storage.
      *
      * @param guild

--- a/src/managers/configuration.manager.ts
+++ b/src/managers/configuration.manager.ts
@@ -193,6 +193,20 @@ export class ConfigurationManager {
     }
 
     /**
+     * Get the default value of the configuration.
+     *
+     * @param key
+     */
+    static getDefaultValue(key: string): string | null {
+        const configuration = this.getDefaultConfiguration(key);
+        if (!configuration) {
+            return null;
+        }
+
+        return configuration.defaultValue;
+    }
+
+    /**
      * Determine whether the configuration is per-guild only.
      *
      * @param key

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3,6 +3,8 @@ export declare global {
         interface Global {
             BOT_COLOR: number;
             SUCCESS_COLOR: number;
+
+            LOCAL: boolean;
         }
     }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -12,6 +12,7 @@ export declare global {
             description: string;
             defaultValue?: string;
             guild: boolean;
+            hidden?: boolean;
         }
     }
 }


### PR DESCRIPTION
## Release Notes

### Hidden Configurations (Development)

As sometimes the configuration option should not be visible or should not be editable through the `[p]config` command, an option to hide it has been added. This is useful only for contributors to this repository if they decide to create a feature using the configuration system without spoiling the value. Though, as I think it can be very useful, I have added it to these release notes.

### Bot Prefix

As one guild can have a lot of bots and therefore, there can be easily a collision of command prefixes, an option to change this prefix has been added. It is connected with the guild, and the configuration system has been used for it. Though, it does not mean it can be changed through the configuration command. The value has been hidden by the above-mentioned feature. To change the command prefix, use a new `[p]prefix` command. If no parameters are forwarded, the bot tells you the current one.

If the bot is in the development mode, the `[p]prefix` command cannot be run, and the `BOT_PREFIX` environment variable is used instead.

### Inviting the Bot

As the bot can be easily used by more guilds and members, an option to generate the invite link has been added; a new `[p]join` command. Though, if you decide you do not want to let others use your instance, you can disable inviting the bot in the Discord application settings. On top of it, change the `invite` configuration to `false`.

## All Changes

### Added

- Added an option to change the bot prefix per-guild with a new `[p]prefix` command
- Added a command to generate the bot invite link; `[p]join`
- Added an option to hide configurations from the `[p]config` command output

### Changes

- Added command details to the `[p]help` command output
- Removed Markdown in the command description from the `[p]help` command output
- Updated dependencies