### PR TITLE
Change the default command prefix

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,7 @@
     "prefix": {
         "name": "Command prefix",
         "description": "Prefix used for calling commands in a guild.",
-        "defaultValue": "+",
+        "defaultValue": "-",
         "guild": true,
         "hidden": true
     },


### PR DESCRIPTION
Due to possible conflicts with other bots, the default prefix has been changed to `-` (previously `+`).